### PR TITLE
fixed numpy 1.12 TypeError

### DIFF
--- a/python/render.py
+++ b/python/render.py
@@ -40,7 +40,7 @@ def vec2im(V, shape = () ):
     '''
 
     if len(shape) < 2:
-        shape = [np.sqrt(V.size)]*2
+        shape = [int(np.sqrt(V.size))]*2
 
     return np.reshape(V, shape)
 


### PR DESCRIPTION
On Numpy 1.12, numpy.reshape does not accept shapes of type float.

```
Traceback (most recent call last):
  File "lrp_demo.py", line 73, in <module>
    digit = render.digit_to_rgb(x, scaling = 3)
  File "/lrp_toolbox/python/render.py", line 158, in digit_to_rgb
    image = enlarge_image(vec2im(X,shape), scaling) #enlarge
  File "lrp_toolbox/python/render.py", line 45, in vec2im
    return np.reshape(V, shape)
  File "/usr/local/lib/python2.7/dist-packages/numpy/core/fromnumeric.py", line 232, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
  File "/usr/local/lib/python2.7/dist-packages/numpy/core/fromnumeric.py", line 67, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File "/usr/local/lib/python2.7/dist-packages/numpy/core/fromnumeric.py", line 47, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
TypeError: 'numpy.float64' object cannot be interpreted as an index
```

This edit fixes the issue.